### PR TITLE
Refactor and implement use cases single page

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -70,13 +70,10 @@ export const createPages: GatsbyNode["createPages"] = async ({
   //@ts-ignore
   createEvents({ actions, graphql, createNodeId, getCache });
 
-
-
   // await createUseCases({ createPage, graphql, resolve });
   // await createTtrss({ createPage, graphql, resolve });
   // await createLeaves({ createPage, graphql, fetchThumbnail, createNode, createNodeId, getCache, resolve });
   // await createVideos({ createPage, graphql, resolve });
-
 
   //----------------------------------------------------------------------------
   //Leaves Pictures Processing
@@ -110,28 +107,28 @@ export const createPages: GatsbyNode["createPages"] = async ({
     }
   `);
   const failingUrls = [
-    'blogs.vmware.com',
-    'https://www.how2shout.com/linux/2-ways-to-install-cassandra-on-ubuntu-22-04-lts-jammy/',
-    'blog.softwaremill',
-    'www.ktexperts',
-    'rustyrazorblade.com',
-    'https://docs.d2iq.com/mesosphere/dcos/services/cassandra/2.9.0-3.11.6/security/',
-    '/www.an10.io/',
-    'itnext.io',
-    '/www.an10.io/',
-    'baeldung.com',
-    '/levelup.gitconnected',
-    'cassandra.apache.org/blog',
-    'Failed to fetch thumbnail for event: https://docs.d2iq.com/mesosphere/dcos/services/cassandra/2.9.0-3.11.6/security/',
-    'datanami.com',
-    'https://dataedo.com/',
-    'https://www.datastax.com/resources/webinar/serverless-functions-datastax-drivers',
-    'https://towardsdatascience.com/',
-    'https://medium.com/better-programming/our-favorite-engineering-blogs-3d8365b2d871',
-    'https://datastation.multiprocess',
-    'tobert.github.io',
-    'zeppelin.apache.org',
-    'https://docs.datastax.com/en/articles/cassandra/cassandrathenandnow.html',
+    "blogs.vmware.com",
+    "https://www.how2shout.com/linux/2-ways-to-install-cassandra-on-ubuntu-22-04-lts-jammy/",
+    "blog.softwaremill",
+    "www.ktexperts",
+    "rustyrazorblade.com",
+    "https://docs.d2iq.com/mesosphere/dcos/services/cassandra/2.9.0-3.11.6/security/",
+    "/www.an10.io/",
+    "itnext.io",
+    "/www.an10.io/",
+    "baeldung.com",
+    "/levelup.gitconnected",
+    "cassandra.apache.org/blog",
+    "Failed to fetch thumbnail for event: https://docs.d2iq.com/mesosphere/dcos/services/cassandra/2.9.0-3.11.6/security/",
+    "datanami.com",
+    "https://dataedo.com/",
+    "https://www.datastax.com/resources/webinar/serverless-functions-datastax-drivers",
+    "https://towardsdatascience.com/",
+    "https://medium.com/better-programming/our-favorite-engineering-blogs-3d8365b2d871",
+    "https://datastation.multiprocess",
+    "tobert.github.io",
+    "zeppelin.apache.org",
+    "https://docs.datastax.com/en/articles/cassandra/cassandrathenandnow.html",
   ];
 
   const filteredNodes = allLeavesPictures?.data?.allApiLeaves?.nodes.filter(
@@ -204,24 +201,76 @@ export const createPages: GatsbyNode["createPages"] = async ({
     data?: {
       allAirtable: {
         nodes: {
-          table: string;
           data: {
-            Case_Description: string;
             Case_Name: string;
+            Case_Description: string;
+            Case_URL: string;
             Case_Article_Content: string;
+            Case_Published: string;
+            Case_Company: {
+              data: {
+                Name: string;
+              };
+              id: number;
+            };
+          };
+        }[];
+      };
+      allFile: {
+        nodes: {
+          childImageSharp: {
+            gatsbyImageData: {
+              layout: string;
+              backgroundColor: string;
+              images: {
+                fallback: {
+                  src: string;
+                  srcSet: string;
+                  sizes: string;
+                };
+                sources: {
+                  srcSet: string;
+                  type: string;
+                  sizes: string;
+                }[];
+              };
+              width: number;
+              height: number;
+            };
+          };
+          parent: {
+            id: string;
           };
         }[];
       };
     };
   } = await graphql(`
     query UseCasesData {
-      allAirtable(filter: { table: { eq: "Cases" } }) {
+      allAirtable(
+        filter: { table: { eq: "Cases" } }
+        sort: { data: { Case_Published: DESC } }
+      ) {
         nodes {
-          table
           data {
+            Case_URL
             Case_Name
             Case_Description
+            Case_Company {
+              data {
+                Name
+              }
+              id
+            }
+            Case_Published
             Case_Article_Content
+          }
+        }
+      }
+      allFile(filter: { id: { ne: null } }) {
+        nodes {
+          name
+          childrenImageSharp {
+            gatsbyImageData
           }
         }
       }
@@ -236,14 +285,29 @@ export const createPages: GatsbyNode["createPages"] = async ({
     console.log("No data found!");
     return;
   }
+  function selectRandomItems(items: any[], numItems: number) {
+    const shuffled = items.slice().sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, numItems);
+  }
   allUseCases.data.allAirtable.nodes.forEach((node) => {
+    // @ts-ignore
+    const exploreFurther = selectRandomItems(
+      // @ts-ignore
+      allUseCases.data.allAirtable.nodes,
+      12
+    );
+
+    // @ts-ignore
+    const newestCases = allUseCases.data.allAirtable.nodes.slice(0, 10);
+    const images = allUseCases.data?.allFile.nodes;
     createPage({
       path: `/use-cases/${getSlug(node.data.Case_Name)}`,
       component: resolve(`src/components/Templates/UseCaseSinglePage.tsx`),
       context: {
-        Description: node.data.Case_Description,
-        Name: node.data.Case_Name,
-        Case_Article_Content: node.data.Case_Article_Content,
+        node,
+        newestCases,
+        exploreFurther,
+        images,
       },
     });
   });

--- a/src/components/Templates/UseCaseSinglePage.tsx
+++ b/src/components/Templates/UseCaseSinglePage.tsx
@@ -3,45 +3,93 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { Container, Typography } from "@mui/material";
 import Layout from "../Layout/Layout";
-import './singlePageTemplates.css'
+import "./singlePageTemplates.css";
+import SinglePageBaseGrid from "../../layouts/SinglePageLayout/SinglePageBaseGrid";
+import { IGatsbyImageData } from "gatsby-plugin-image";
 
+interface ImageData {
+  name: string;
+  childrenImageSharp: {
+    gatsbyImageData: IGatsbyImageData;
+  }[];
+}
 interface UseCasesSinglePageProps {
   pageContext: {
-    id: string;
-    title: string;
-    Description: string;
-    Case_Article_Content: string;
+    node: {
+      data: {
+        Case_Name: string;
+        Case_Description: string;
+        Case_URL: string;
+        Case_Article_Content: string;
+        Case_Published: string;
+        Case_Company: {
+          data: {
+            Name: string;
+          };
+          id: number;
+        };
+      };
+    };
+    newestCases: [];
+    exploreFurther: [];
+    images: ImageData[];
   };
 }
 
 const UseCasesSinglePage: React.FC<UseCasesSinglePageProps> = ({
-  pageContext: { id, title, Description, Case_Article_Content },
+  pageContext: { node, newestCases, exploreFurther, images },
 }) => {
+  function getCurrentCompanies(exploreFurther: any[], images: any[]) {
+    return exploreFurther.map((node: any) => {
+      const companyName = node.data.Case_Company[0]?.data.Name.split(" ")
+        .join("")
+        .toLowerCase();
+      const logoFile = images.find(
+        (file) => file.name === `case.logo.${companyName}`
+      );
+
+      return {
+        ...node.data,
+        thumbnail: logoFile?.childrenImageSharp[0]?.gatsbyImageData || null,
+      };
+    });
+  }
+  const exploreFurtherCases = getCurrentCompanies(exploreFurther, images);
+  const singlePageWithThumbnail = getCurrentCompanies([node], images);
+  const newestRelatedCases = getCurrentCompanies(newestCases, images);
+
+  // Im mapping the useCases to object like leaf so i dont have to change every component down the line
+  let singlePageNode = {
+    tags: [],
+    title: singlePageWithThumbnail[0].Case_Name,
+    wallabag_created_at: singlePageWithThumbnail[0].Case_Published,
+    description: singlePageWithThumbnail[0].Case_Description,
+    id: singlePageWithThumbnail[0].Case_Company[0].id,
+    content: singlePageWithThumbnail[0].Case_Article_Content,
+    url: singlePageWithThumbnail[0].Case_URL,
+    origin_url: singlePageWithThumbnail[0].Case_URL,
+    reading_time: 0,
+    domain_name: "",
+    preview_picture: "",
+    thumbnail: singlePageWithThumbnail[0].thumbnail,
+  };
+  // something similiar needs to be done to newestRelatedCases and exploreFurtherCases
   return (
     <Layout>
-      <Container>
-        <Helmet>
-          <title>{title}</title>
-        </Helmet>
-        <div className="articleContainer" style={{ marginInline: "30px" }}>
-          <article>
-            <Typography
-              variant="h4"
-              dangerouslySetInnerHTML={{ __html: title }}
-            />
-            <Typography
-              variant="subtitle2"
-              gutterBottom
-              dangerouslySetInnerHTML={{ __html: Description }}
-            />
-            <Typography
-              variant="subtitle2"
-              gutterBottom
-              dangerouslySetInnerHTML={{ __html: Case_Article_Content }}
-            />
-          </article>
-        </div>
-      </Container>
+      <Helmet>
+        <title>{singlePageNode.title}</title>
+        <meta
+          name={singlePageNode.title}
+          content={singlePageNode.description}
+        />
+      </Helmet>
+      <SinglePageBaseGrid
+        args={{
+          singlePage: singlePageNode,
+          relatedArticles: newestRelatedCases,
+          tagSets: exploreFurtherCases,
+        }}
+      />
     </Layout>
   );
 };

--- a/src/layouts/SinglePageLayout/SinglePageBaseGrid.tsx
+++ b/src/layouts/SinglePageLayout/SinglePageBaseGrid.tsx
@@ -73,7 +73,7 @@ const SinglePageBaseGrid: React.FC<SinglePageProps> = ({
           <Grid item xs={12} sm={4}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                <RelatedArticlesLayout data={relatedArticles} />
+                {/* <RelatedArticlesLayout data={relatedArticles} /> */}
               </Grid>
               <Grid item xs={12}>
                 <TrainingAdComponent />
@@ -88,12 +88,12 @@ const SinglePageBaseGrid: React.FC<SinglePageProps> = ({
           <ExploreRelatedTopics />
         </Grid>
         <Grid sx={{ marginBottom: 4 }} item xs={12}>
-          <ExploreFurtherLayout
+          {/* <ExploreFurtherLayout
             args={{
               data: tagSets,
               isListingPage: false,
             }}
-          />
+          /> */}
         </Grid>
         <Grid item xs={12}>
           {/* comments section */}


### PR DESCRIPTION
This PR adds the following features:

* Add functionality to find newest and random use cases in gatsby-node file
* Implement single page grid in single page use case component

Notes: 
I mapped the singleNode object to be the same as it was for leaves, this way we can avoid adding logic down the line to all components. This needs to be done for newest and random use cases arrays if possible, so their objects are the same as singleNode(see UseCasesSinglePage.tsx line 61). If not we can make separate logic in exploreFurtherLayout and relatedArticles so it works with those arrays too