### PR TITLE
Fixes for Issues 151,152,154

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -93,7 +93,7 @@ const HeroSection = () => {
             variant="subtitle1"
             className="Font_Lato_Bold"
           >
-            Cassandra has a robust and active community of users and developers,
+          Apache Cassandra® a robust and active community of users and developers,
           who contribute to its development and use it in a variety of
           applications, ranging from e-commerce to real-time analytics.{" "}
           </Typography>

--- a/src/components/Navigation/DropdownAccordion.tsx
+++ b/src/components/Navigation/DropdownAccordion.tsx
@@ -21,7 +21,7 @@ const Resources: Resource[] = [
     href: "https://prodcassandra.wpengine.com/eventspage/",
     target: "_blank",
   },
-  { name: "Handbook", href: "https://cassandra.apache.org/_/events.html" },
+  { name: "Apache Events", href: "https://cassandra.apache.org/_/events.html" },
 ];
 
 export default function DropdownAccordion(): JSX.Element {

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -194,7 +194,7 @@ function ResponsiveAppBar({ openNav, setOpenNav }: any) {
                         }}
                         onClick={handleCloseEvent}
                       >
-                        Handbook
+                        Apache Events
                       </MenuItem>
                     </Link>
                   </Menu>

--- a/src/components/Templates/NewsSinglePage.tsx
+++ b/src/components/Templates/NewsSinglePage.tsx
@@ -79,7 +79,7 @@ const PostSinglePage: React.FC<PostSinglePageProps> = ({
             </article>
             <Link style={{ textDecoration: "none", marginLeft: 3 }} to={link}>
               <Button variant="contained" color="primary">
-                Continue Reading
+                See Original
               </Button>
             </Link>
           </Grid>


### PR DESCRIPTION
## Update Notice: Compliance with Apache Foundation Guidelines for Community Site

We are excited to announce that we've made important updates to align our community site with the guidelines set forth by the Apache Foundation for Apache Cassandra®. Below are the specific changes we've made:

### 1. Correct Usage of Project Name

We have updated all occurrences of the project name to use the full Apache project name, "Apache Cassandra®," in titles and in the first mention on every page. This change also extends to our homepage, where the name "Apache Cassandra®" is now used with the registered trademark symbol.

### 2. Navigation Bar Update

A prominent link to "Apache Cassandra®," leading to [cassandra.apache.org](https://cassandra.apache.org), has been added to the top navigation bar of our website. This link is available on every page.

### 3. Aggregated Pages Link Text

On aggregated pages featuring content from different websites, the "continue reading" link text has been updated. The new text informs readers that they will be directed to an external website in a new window or tab.


